### PR TITLE
Fixing bug int arrayCopy2 where copied data is lost

### DIFF
--- a/src/jdbpfx/util/DBPFPackager.java
+++ b/src/jdbpfx/util/DBPFPackager.java
@@ -82,6 +82,10 @@ public class DBPFPackager {
     /**
      * Copies data from source to destination array.<br>
      * The copy is byte by byte from srcPos to destPos and given length.
+     * If the destination array is not large enough a new array will be
+     * created.  Since the new array will be a different object, callers
+     * should always update their reference to the original dest array
+     * with the returned value.
      *
      * @param src
      *            The source array
@@ -93,8 +97,10 @@ public class DBPFPackager {
      *            The destination position
      * @param length
      *            The length
+     * @return
+     *            The destination array 
      */
-    private void arrayCopy2(byte[] src, int srcPos, byte[] dest, int destPos, int length) {
+    private byte[] arrayCopy2(byte[] src, int srcPos, byte[] dest, int destPos, int length) {
         // This shouldn't occur, but to prevent errors
         if (dest.length < destPos + length) {
             if (debug) {
@@ -111,6 +117,8 @@ public class DBPFPackager {
         for (int i = 0; i < length; i++) {
             dest[destPos + i] = src[srcPos + i];
         }
+
+        return dest;
     }
 
     /**
@@ -256,7 +264,7 @@ public class DBPFPackager {
                             cData[writeIndex++] = (byte) (0xE0 + copyCount);
                             copyCount = 4 * copyCount + 4;
 
-                            arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
+                            cData = arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
                             lastReadIndex += copyCount;
                             writeIndex += copyCount;
                         }
@@ -296,7 +304,7 @@ public class DBPFPackager {
                         // }
 
                         // do the offset copy
-                        arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
+                        cData = arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
                         writeIndex += copyCount;
                         lastReadIndex += copyCount;
                         lastReadIndex += offsetCopyCount;
@@ -315,7 +323,7 @@ public class DBPFPackager {
                     cData[writeIndex++] = (byte) (0xE0 + copyCount);
                     copyCount = 4 * copyCount + 4;
 
-                    arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
+                    cData = arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
                     lastReadIndex += copyCount;
                     writeIndex += copyCount;
                 }
@@ -336,7 +344,7 @@ public class DBPFPackager {
                 // }
                 copyCount = index - lastReadIndex;
                 cData[writeIndex++] = (byte) (0xfc + copyCount);
-                arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
+                cData = arrayCopy2(dData, lastReadIndex, cData, writeIndex, copyCount);
                 writeIndex += copyCount;
                 lastReadIndex += copyCount;
 
@@ -420,7 +428,7 @@ public class DBPFPackager {
                         int control2 = cData[pos] & 0xFF;
                         pos++;
                         int numberOfPlainText = (control1 & 0x03);
-                        arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
+                        dData = arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
                         dpos += numberOfPlainText;
                         pos += numberOfPlainText;
 
@@ -437,7 +445,7 @@ public class DBPFPackager {
                         pos++;
 
                         int numberOfPlainText = (control2 >> 6) & 0x03;
-                        arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
+                        dData = arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
                         dpos += numberOfPlainText;
                         pos += numberOfPlainText;
 
@@ -454,7 +462,7 @@ public class DBPFPackager {
                         pos++;
                         int control4 = cData[pos] & 0xFF;
                         pos++;
-                        arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
+                        dData = arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
                         dpos += numberOfPlainText;
                         pos += numberOfPlainText;
 
@@ -465,12 +473,12 @@ public class DBPFPackager {
                     } else if (control1 >= 224 && control1 <= 251) {
                         // 0xE0 - 0xFB
                         int numberOfPlainText = ((control1 & 0x1F) << 2) + 4;
-                        arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
+                        dData = arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
                         dpos += numberOfPlainText;
                         pos += numberOfPlainText;
                     } else {
                         int numberOfPlainText = (control1 & 0x03);
-                        arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
+                        dData = arrayCopy2(cData, pos, dData, dpos, numberOfPlainText);
                         dpos += numberOfPlainText;
                         pos += numberOfPlainText;
                     }


### PR DESCRIPTION
In the event where the destination array is not large enough
the arrayCopy2 function was creating a larger array and copying the
data in the new array, however, the original array passed in as a reference
was not updated.
